### PR TITLE
Updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,16 @@ jobs:
             artifact_name: "Linux",
             cores: 2,
           }
+          - {
+            name: "Mac OS / Clang 11",
+            os: macos-11.0,
+            config: Release,
+            cxx_standard: 20,
+            cmake_extra_args: "-DCMAKE_C_COMPILER=/usr/local/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/bin/clang++  -DCMAKE_CXX_FLAGS=\"-O2\"",
+            sudocmd: "sudo",
+            artifact_name: "MacOSX",
+            cores: 4,
+          }
     steps:
       - uses: actions/checkout@v2
       - name: Update GCC
@@ -47,6 +57,16 @@ jobs:
           sudo apt-get install -y g++-10 g++-10-multilib
           name=CC::gcc-10
           name=CXX::g++-10
+      - name: Update Clang
+        if: matrix.config.os == 'macos-11.0'
+        run: |
+          curl --output clang.tar.xz -L https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/clang+llvm-11.0.0-x86_64-apple-darwin.tar.xz
+          mkdir clang
+          tar -xvJf clang.tar.xz -C clang
+          cd clang/clang+llvm-11.0.0-x86_64-apple-darwin
+          sudo cp -R * /usr/local/
+          export CC=/usr/local/bin/clang
+          export CXX=/usr/local/bin/clang++
       - name: Create Work Dir
         run: mkdir build
       - name: Configure Build Script
@@ -62,9 +82,9 @@ jobs:
       - name: Install
         working-directory: ./build
         run: ${{ matrix.config.sudocmd }} cmake --install .
-      - name: Create packages
-        working-directory: ./build
-        run: ${{ matrix.config.sudocmd }} cpack
+      #- name: Create packages
+      #  working-directory: ./build
+      #  run: ${{ matrix.config.sudocmd }} cpack
       - name: Archive Installer Packages
         uses: actions/upload-artifact@v2
         with:

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -31,7 +31,6 @@ add_library(portfolio
         portfolio/portfolio.cpp
         portfolio/portfolio.h
 )
-
 target_include_directories(portfolio
         PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -9,6 +9,13 @@ CPMAddPackage(NAME range-v3 URL https://github.com/ericniebler/range-v3/archive/
 add_library(range-v3 INTERFACE IMPORTED)
 target_include_directories(range-v3 INTERFACE "${range-v3_SOURCE_DIR}/include")
 
+# Howard Hinnant's date library
+CPMAddPackage(
+        NAME date
+        GITHUB_REPOSITORY HowardHinnant/date
+        VERSION 3.0.0
+)
+
 #######################################################
 ### Library                                         ###
 #######################################################
@@ -28,6 +35,6 @@ add_library(portfolio
 target_include_directories(portfolio
         PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
-target_link_libraries(portfolio PUBLIC Threads::Threads range-v3)
+target_link_libraries(portfolio PUBLIC Threads::Threads range-v3 date::date)
 target_pedantic_options(portfolio)
 target_exception_options(portfolio)

--- a/source/portfolio/data_feed/data_feed.h
+++ b/source/portfolio/data_feed/data_feed.h
@@ -12,10 +12,9 @@
 namespace portfolio {
     class data_feed {
       public:
-        virtual data_feed_result fetch(std::string_view asset_code) = 0;
-        virtual data_feed_result fetch_from(std::string_view asset_code,
-                                            date::year_month_day from_date,
-                                            date::year_month_day to_date) = 0;
+        virtual data_feed_result fetch(std::string_view asset_code,
+                                       date::year_month_day from_date,
+                                       date::year_month_day to_date) = 0;
     };
 }
 

--- a/source/portfolio/data_feed/data_feed.h
+++ b/source/portfolio/data_feed/data_feed.h
@@ -5,18 +5,24 @@
 #ifndef PORTFOLIO_DATA_FEED_H
 #define PORTFOLIO_DATA_FEED_H
 
-#include "date/date.h"
+#include <chrono>
+#include <date/date.h>
 #include <portfolio/data_feed/data_feed_result.h>
 #include <string_view>
 
 namespace portfolio {
+    enum class timeframe { daily, weekly, monthly, hourly, minutes_15 };
     class data_feed {
       public:
-        virtual data_feed_result fetch(std::string_view asset_code,
-                                       date::year_month_day from_date,
-                                       date::year_month_day to_date) = 0;
+        virtual data_feed_result
+        fetch(std::string_view asset_code,
+              std::chrono::time_point<std::chrono::system_clock,
+                                      std::chrono::minutes>
+                  start_period,
+              std::chrono::time_point<std::chrono::system_clock,
+                                      std::chrono::minutes>
+                  end_period,
+              timeframe tf) = 0;
     };
-}
-
-
+} // namespace portfolio
 #endif //PORTFOLIO_DATA_FEED_H

--- a/source/portfolio/data_feed/data_feed.h
+++ b/source/portfolio/data_feed/data_feed.h
@@ -5,13 +5,17 @@
 #ifndef PORTFOLIO_DATA_FEED_H
 #define PORTFOLIO_DATA_FEED_H
 
-#include <string_view>
+#include "date/date.h"
 #include <portfolio/data_feed/data_feed_result.h>
+#include <string_view>
 
 namespace portfolio {
     class data_feed {
-    public:
+      public:
         virtual data_feed_result fetch(std::string_view asset_code) = 0;
+        virtual data_feed_result fetch_from(std::string_view asset_code,
+                                            date::year_month_day from_date,
+                                            date::year_month_day to_date) = 0;
     };
 }
 

--- a/source/portfolio/data_feed/data_feed_result.cpp
+++ b/source/portfolio/data_feed/data_feed_result.cpp
@@ -16,10 +16,15 @@ namespace portfolio {
 
     double data_feed_result::price_from_date(date::year_month_day date) const {
         auto it = historical_data_.lower_bound(date);
-        if (it == historical_data_.end())
-            return historical_data_.rbegin()->second;
-        else
+        if (historical_data_.end() != historical_data_.find(date) ||
+            it == historical_data_.begin()) {
             return (*it).second;
+        } else if (it == historical_data_.end()) {
+            return historical_data_.rbegin()->second;
+        } else {
+            it--;
+            return (*it).second;
+        }
     }
 
     data_feed_result::data_feed_result(

--- a/source/portfolio/data_feed/data_feed_result.cpp
+++ b/source/portfolio/data_feed/data_feed_result.cpp
@@ -7,15 +7,9 @@
 namespace portfolio {
     double data_feed_result::current_price() const { return current_price_; }
 
-    data_feed_result::data_feed_result(double current_price)
-        : current_price_(current_price) {
-        date::year_month_day today =
-            floor<date::days>(std::chrono::system_clock::now());
-        historical_data_[today] = current_price;
-    }
-
-    double data_feed_result::price_from_date(date::year_month_day date) const {
+    double data_feed_result::price(date::year_month_day date) const {
         auto it = historical_data_.lower_bound(date);
+
         if (historical_data_.end() != historical_data_.find(date) ||
             it == historical_data_.begin()) {
             return (*it).second;
@@ -32,6 +26,6 @@ namespace portfolio {
         : historical_data_(historical_data) {
         date::year_month_day today =
             floor<date::days>(std::chrono::system_clock::now());
-        current_price_ = price_from_date(today);
+        current_price_ = price(today);
     }
 } // namespace portfolio

--- a/source/portfolio/data_feed/data_feed_result.cpp
+++ b/source/portfolio/data_feed/data_feed_result.cpp
@@ -4,16 +4,39 @@
 
 #include "data_feed_result.h"
 #include <chrono>
+#include <utility>
 namespace portfolio {
-    double data_feed_result::current_price() const { return current_price_; }
+    double data_feed_result::lastest_price() const {
+        // return last price in historical data
+        return historical_data_.rbegin()->second;
+    }
 
-    double data_feed_result::price(date::year_month_day date) const {
-        auto it = historical_data_.find(date);
-        // if date is founded
-        if (it != historical_data_.end()) {
+    data_feed_result::data_feed_result(
+        std::map<std::chrono::time_point<std::chrono::system_clock,
+                                         std::chrono::minutes>,
+                 double>
+            historical_data)
+        : historical_data_(std::move(historical_data)) {}
+    double data_feed_result::price_from(
+        std::chrono::time_point<std::chrono::system_clock, std::chrono::minutes>
+            date_time) const {
+        auto it = historical_data_.find(date_time);
+        const bool date_time_is_found = it != historical_data_.end();
+        if (date_time_is_found) {
+            return it->second;
+        } else {
+            return -1;
+        }
+    }
+    double data_feed_result::closest_price(
+        std::chrono::time_point<std::chrono::system_clock, std::chrono::minutes>
+            date_time) const {
+        auto it = historical_data_.find(date_time);
+        const bool date_time_is_found = it != historical_data_.end();
+        if (date_time_is_found) {
             return (*it).second;
         } else {
-            it = historical_data_.lower_bound(date);
+            it = historical_data_.lower_bound(date_time);
             if (it == historical_data_.begin()) {
                 // if date is lower than oldest date in historical
                 // returns the oldest price in historical
@@ -26,16 +49,8 @@ namespace portfolio {
                 // if the date is weekend day
                 // returns the price of the previous day in historical
                 it--;
-                return (*it).second;
+                return it->second;
             }
         }
-    }
-
-    data_feed_result::data_feed_result(
-        const std::map<date::year_month_day, double> &historical_data)
-        : historical_data_(historical_data) {
-        date::year_month_day today =
-            floor<date::days>(std::chrono::system_clock::now());
-        current_price_ = price(today);
     }
 } // namespace portfolio

--- a/source/portfolio/data_feed/data_feed_result.cpp
+++ b/source/portfolio/data_feed/data_feed_result.cpp
@@ -8,16 +8,26 @@ namespace portfolio {
     double data_feed_result::current_price() const { return current_price_; }
 
     double data_feed_result::price(date::year_month_day date) const {
-        auto it = historical_data_.lower_bound(date);
-
-        if (historical_data_.end() != historical_data_.find(date) ||
-            it == historical_data_.begin()) {
+        auto it = historical_data_.find(date);
+        // if date is founded
+        if (it != historical_data_.end()) {
             return (*it).second;
-        } else if (it == historical_data_.end()) {
-            return historical_data_.rbegin()->second;
         } else {
-            it--;
-            return (*it).second;
+            it = historical_data_.lower_bound(date);
+            if (it == historical_data_.begin()) {
+                // if date is lower than oldest date in historical
+                // returns the oldest price in historical
+                return historical_data_.cbegin()->second;
+            } else if (it == historical_data_.end()) {
+                // if the date is higher than the newest date in historical
+                // returns the newest price in historical
+                return historical_data_.rbegin()->second;
+            } else {
+                // if the date is weekend day
+                // returns the price of the previous day in historical
+                it--;
+                return (*it).second;
+            }
         }
     }
 

--- a/source/portfolio/data_feed/data_feed_result.cpp
+++ b/source/portfolio/data_feed/data_feed_result.cpp
@@ -3,11 +3,30 @@
 //
 
 #include "data_feed_result.h"
-
+#include <chrono>
 namespace portfolio {
-    double data_feed_result::current_price() const {
-        return current_price_;
+    double data_feed_result::current_price() const { return current_price_; }
+
+    data_feed_result::data_feed_result(double current_price)
+        : current_price_(current_price) {
+        date::year_month_day today =
+            floor<date::days>(std::chrono::system_clock::now());
+        historical_data_[today] = current_price;
     }
 
-    data_feed_result::data_feed_result(double current_price) : current_price_(current_price) {}
-}
+    double data_feed_result::price_from_date(date::year_month_day date) const {
+        auto it = historical_data_.lower_bound(date);
+        if (it == historical_data_.end())
+            return historical_data_.rbegin()->second;
+        else
+            return (*it).second;
+    }
+
+    data_feed_result::data_feed_result(
+        const std::map<date::year_month_day, double> &historical_data)
+        : historical_data_(historical_data) {
+        date::year_month_day today =
+            floor<date::days>(std::chrono::system_clock::now());
+        current_price_ = price_from_date(today);
+    }
+} // namespace portfolio

--- a/source/portfolio/data_feed/data_feed_result.h
+++ b/source/portfolio/data_feed/data_feed_result.h
@@ -5,16 +5,22 @@
 #ifndef PORTFOLIO_DATA_FEED_RESULT_H
 #define PORTFOLIO_DATA_FEED_RESULT_H
 
+#include "date/date.h"
+#include <map>
+
 namespace portfolio {
     class data_feed_result {
-    public /* constructors */:
+      public /* constructors */:
         explicit data_feed_result(double currentPrice);
-
-    public /* getters and setters */:
+        explicit data_feed_result(
+            const std::map<date::year_month_day, double> &historical_data);
+      public /* getters and setters */:
         [[nodiscard]] double current_price() const;
+        [[nodiscard]] double price_from_date(date::year_month_day date) const;
 
-    private:
+      private:
         double current_price_;
+        std::map<date::year_month_day, double> historical_data_;
     };
 }
 

--- a/source/portfolio/data_feed/data_feed_result.h
+++ b/source/portfolio/data_feed/data_feed_result.h
@@ -11,12 +11,11 @@
 namespace portfolio {
     class data_feed_result {
       public /* constructors */:
-        explicit data_feed_result(double currentPrice);
         explicit data_feed_result(
             const std::map<date::year_month_day, double> &historical_data);
       public /* getters and setters */:
         [[nodiscard]] double current_price() const;
-        [[nodiscard]] double price_from_date(date::year_month_day date) const;
+        [[nodiscard]] double price(date::year_month_day date) const;
 
       private:
         double current_price_;

--- a/source/portfolio/data_feed/data_feed_result.h
+++ b/source/portfolio/data_feed/data_feed_result.h
@@ -5,21 +5,34 @@
 #ifndef PORTFOLIO_DATA_FEED_RESULT_H
 #define PORTFOLIO_DATA_FEED_RESULT_H
 
-#include "date/date.h"
+#include <chrono>
+#include <date/date.h>
 #include <map>
 
 namespace portfolio {
     class data_feed_result {
       public /* constructors */:
         explicit data_feed_result(
-            const std::map<date::year_month_day, double> &historical_data);
+            std::map<std::chrono::time_point<std::chrono::system_clock,
+                                             std::chrono::minutes>,
+                     double>
+                historical_data);
       public /* getters and setters */:
-        [[nodiscard]] double current_price() const;
-        [[nodiscard]] double price(date::year_month_day date) const;
+        [[maybe_unused]] [[nodiscard]] double lastest_price() const;
+        [[nodiscard]] double
+        price_from(std::chrono::time_point<std::chrono::system_clock,
+                                           std::chrono::minutes>
+                       date_time) const;
+        [[nodiscard]] double
+        closest_price(std::chrono::time_point<std::chrono::system_clock,
+                                              std::chrono::minutes>
+                          date_time) const;
 
       private:
-        double current_price_;
-        std::map<date::year_month_day, double> historical_data_;
+        std::map<std::chrono::time_point<std::chrono::system_clock,
+                                         std::chrono::minutes>,
+                 double>
+            historical_data_;
     };
 }
 

--- a/source/portfolio/data_feed/mock_data_feed.cpp
+++ b/source/portfolio/data_feed/mock_data_feed.cpp
@@ -3,7 +3,6 @@
 //
 
 #include "mock_data_feed.h"
-#include <iostream>
 #include <random>
 
 using day_point =
@@ -47,15 +46,11 @@ namespace portfolio {
                 double volatility = (ud_double(generator) - 1) * 5;
                 side < 30 ? current_price *= 1 - (volatility / 100)
                           : current_price *= 1 + (volatility / 100);
-                if (current_price > 0) { // no negatives prices
-                    historical[date::year_month_day(i)] = current_price;
-                } else {
-                    historical[date::year_month_day(i)] = 0;
-                }
+                // no negatives prices
+                current_price > 0
+                    ? historical[date::year_month_day(i)] = current_price
+                    : historical[date::year_month_day(i)] = 0;
             }
-        }
-        for (auto p : historical) {
-            std::cout << p.first << " - " << p.second << std::endl;
         }
         return historical;
     }

--- a/source/portfolio/data_feed/mock_data_feed.cpp
+++ b/source/portfolio/data_feed/mock_data_feed.cpp
@@ -3,9 +3,52 @@
 //
 
 #include "mock_data_feed.h"
-
+#include <random>
 namespace portfolio {
     data_feed_result mock_data_feed::fetch(std::string_view asset) {
         return data_feed_result(27.41);
     }
-}
+
+    data_feed_result mock_data_feed::fetch_from(std::string_view asset_code,
+                                                date::year_month_day from_date,
+                                                date::year_month_day to_date) {
+        using day_point =
+            std::chrono::time_point<std::chrono::system_clock, date::days>;
+        std::map<date::year_month_day, double> historical;
+        day_point from = from_date;
+        day_point to = to_date;
+        // to_date must be greater than from_date
+        if (to < from) {
+            day_point swap = from;
+            from = to;
+            to = swap;
+        }
+        static std::random_device r;
+        static std::default_random_engine generator(r());
+        std::uniform_int_distribution<int> ud_int(10, 50);
+        std::uniform_real_distribution<double> ud_double(1, 2);
+        // initial price between 10.00 and 100.00
+        double current_price = ud_int(generator) * ud_double(generator);
+        historical[date::year_month_day(from)] = current_price;
+        from += date::days{1};
+        for (day_point i = from; i <= to; i += date::days{1}) {
+            // side between 10 ~ 50.
+            // If side less then 30 indicates high prices.
+            // If side greater than 30 indicates low prices
+            int side = ud_int(generator);
+            double volatility = (ud_double(generator) - 1) * 5;
+            if (side < 30) {
+                current_price *= 1 - (volatility / 100);
+            } else {
+                current_price *= 1 + (volatility / 100);
+            }
+            // no negatives prices
+            if (current_price > 0) {
+                historical[date::year_month_day(i)] = current_price;
+            } else {
+                historical[date::year_month_day(i)] = 0;
+            }
+        }
+        return data_feed_result(historical);
+    }
+} // namespace portfolio

--- a/source/portfolio/data_feed/mock_data_feed.cpp
+++ b/source/portfolio/data_feed/mock_data_feed.cpp
@@ -4,6 +4,7 @@
 
 #include "mock_data_feed.h"
 #include <random>
+
 namespace portfolio {
     data_feed_result mock_data_feed::fetch(std::string_view asset) {
         return data_feed_result(27.41);
@@ -29,24 +30,25 @@ namespace portfolio {
         std::uniform_real_distribution<double> ud_double(1, 2);
         // initial price between 10.00 and 100.00
         double current_price = ud_int(generator) * ud_double(generator);
-        historical[date::year_month_day(from)] = current_price;
-        from += date::days{1};
         for (day_point i = from; i <= to; i += date::days{1}) {
-            // side between 10 ~ 50.
-            // If side less then 30 indicates high prices.
-            // If side greater than 30 indicates low prices
-            int side = ud_int(generator);
-            double volatility = (ud_double(generator) - 1) * 5;
-            if (side < 30) {
-                current_price *= 1 - (volatility / 100);
-            } else {
-                current_price *= 1 + (volatility / 100);
-            }
-            // no negatives prices
-            if (current_price > 0) {
-                historical[date::year_month_day(i)] = current_price;
-            } else {
-                historical[date::year_month_day(i)] = 0;
+            // if is not weekend
+            if (i != date::Saturday && i != date::Sunday) {
+                // side between 10 ~ 50.
+                // If side less then 30 indicates high prices.
+                // If side greater than 30 indicates low prices
+                int side = ud_int(generator);
+                double volatility = (ud_double(generator) - 1) * 5;
+                if (side < 30) {
+                    current_price *= 1 - (volatility / 100);
+                } else {
+                    current_price *= 1 + (volatility / 100);
+                }
+                // no negatives prices
+                if (current_price > 0) {
+                    historical[date::year_month_day(i)] = current_price;
+                } else {
+                    historical[date::year_month_day(i)] = 0;
+                }
             }
         }
         return data_feed_result(historical);

--- a/source/portfolio/data_feed/mock_data_feed.cpp
+++ b/source/portfolio/data_feed/mock_data_feed.cpp
@@ -3,55 +3,89 @@
 //
 
 #include "mock_data_feed.h"
+#include <iostream>
 #include <random>
 
 using day_point =
     std::chrono::time_point<std::chrono::system_clock, date::days>;
 namespace portfolio {
-    data_feed_result mock_data_feed::fetch(std::string_view asset_code,
-                                           date::year_month_day from_date,
-                                           date::year_month_day to_date) {
 
-        day_point from = from_date;
-        day_point to = to_date;
-        // to_date must be greater than from_date
-        valid_dates(from, to);
-        return data_feed_result(generate_historical_data(from, to));
+    data_feed_result mock_data_feed::fetch(
+        std::string_view asset_code,
+        std::chrono::time_point<std::chrono::system_clock, std::chrono::minutes>
+            start_period,
+        std::chrono::time_point<std::chrono::system_clock, std::chrono::minutes>
+            end_period,
+        timeframe tf) {
+        return data_feed_result(
+            generate_historical_data(start_period, end_period, tf));
     }
-
-    void mock_data_feed::valid_dates(day_point &from, day_point &to) {
-        if (from > to) {
-            std::chrono::time_point<std::chrono::system_clock, date::days> swap;
-            swap = from;
-            from = to;
-            to = swap;
+    std::chrono::minutes
+    mock_data_feed::calculate_increment(portfolio::timeframe tf) {
+        using namespace std::chrono_literals;
+        switch (tf) {
+        case timeframe::minutes_15:
+            return 15min;
+        case timeframe::daily:
+            return 24h;
+        case timeframe::hourly:
+            return 60min;
+        case timeframe::monthly:
+            return 31 * 24h;
+        case timeframe::weekly:
+            return 7 * 24h;
+        default:
+            return 24h;
         }
     }
-
-    std::map<date::year_month_day, double>
-    mock_data_feed::generate_historical_data(day_point from, day_point to) {
-        std::map<date::year_month_day, double> historical;
+    std::map<std::chrono::time_point<std::chrono::system_clock,
+                                     std::chrono::minutes>,
+             double>
+    mock_data_feed::generate_historical_data(
+        std::chrono::time_point<std::chrono::system_clock, std::chrono::minutes>
+            start_period,
+        std::chrono::time_point<std::chrono::system_clock, std::chrono::minutes>
+            end_period,
+        timeframe tf) {
+        std::chrono::minutes increment = calculate_increment(tf);
+        std::map<std::chrono::time_point<std::chrono::system_clock,
+                                         std::chrono::minutes>,
+                 double>
+            historical;
         static std::random_device r;
         static std::default_random_engine generator(r());
         std::uniform_int_distribution<int> ud_int(10, 50);
         std::uniform_real_distribution<double> ud_double(1, 2);
         // initial price between 10.00 and 100.00
         double current_price = ud_int(generator) * ud_double(generator);
-        for (day_point i = from; i <= to; i += date::days{1}) {
-            if (i != date::Saturday && i != date::Sunday) { // if is not weekend
-                // side between 10 ~ 50.
-                // If side less then 30 indicates high prices.
-                // If side greater than 30 indicates low prices
-                int side = ud_int(generator);
-                double volatility = (ud_double(generator) - 1) * 5;
-                side < 30 ? current_price *= 1 - (volatility / 100)
-                          : current_price *= 1 + (volatility / 100);
-                // no negatives prices
-                current_price > 0
-                    ? historical[date::year_month_day(i)] = current_price
-                    : historical[date::year_month_day(i)] = 0;
+        for (std::chrono::time_point<std::chrono::system_clock,
+                                     std::chrono::minutes>
+                 i = start_period;
+             i <= end_period; i = i + increment) {
+            day_point dp = date::floor<date::days>(i);
+            using namespace date;
+            using namespace std::chrono_literals;
+            if (dp != date::Saturday &&
+                dp != date::Sunday) { // if is not weekend
+                auto time = date::make_time(
+                    std::chrono::duration_cast<std::chrono::minutes>(i - dp));
+                date::hh_mm_ss<std::chrono::seconds> start_time(10h + 0min);
+                date::hh_mm_ss<std::chrono::seconds> end_time(18h + 0min);
+                if (time.to_duration() >= start_time.to_duration() &&
+                    time.to_duration() <= end_time.to_duration()) {
+                    int side = ud_int(generator);
+                    double volatility = (ud_double(generator) - 1) * 5;
+                    side < 30 ? current_price *= 1 - (volatility / 100)
+                              : current_price *= 1 + (volatility / 100);
+                    // no negatives prices
+                    current_price > 0 ? historical[i] = current_price
+                                      : historical[i] = 0;
+                    using namespace date;
+                    std::cout << i << " : " << current_price << std::endl;
+                }
             }
         }
         return historical;
     }
+
 } // namespace portfolio

--- a/source/portfolio/data_feed/mock_data_feed.h
+++ b/source/portfolio/data_feed/mock_data_feed.h
@@ -8,12 +8,19 @@
 #include "date/date.h"
 #include <portfolio/data_feed/data_feed.h>
 
+using day_point =
+    std::chrono::time_point<std::chrono::system_clock, date::days>;
 namespace portfolio {
     class mock_data_feed : public data_feed {
-    public:
-      data_feed_result fetch(std::string_view) override;
-      data_feed_result fetch_from(std::string_view, date::year_month_day,
-                                  date::year_month_day) override;
+      public:
+        data_feed_result fetch(std::string_view, date::year_month_day,
+                               date::year_month_day) override;
+
+      private:
+        // check if from < to. If from > to swap the values
+        static void valid_dates(day_point &from, day_point &to);
+        static std::map<date::year_month_day, double>
+        generate_historical_data(day_point from, day_point to);
     };
 }
 

--- a/source/portfolio/data_feed/mock_data_feed.h
+++ b/source/portfolio/data_feed/mock_data_feed.h
@@ -5,7 +5,8 @@
 #ifndef PORTFOLIO_MOCK_DATA_FEED_H
 #define PORTFOLIO_MOCK_DATA_FEED_H
 
-#include "date/date.h"
+#include <chrono>
+#include <date/date.h>
 #include <portfolio/data_feed/data_feed.h>
 
 using day_point =
@@ -13,14 +14,29 @@ using day_point =
 namespace portfolio {
     class mock_data_feed : public data_feed {
       public:
-        data_feed_result fetch(std::string_view, date::year_month_day,
-                               date::year_month_day) override;
+        data_feed_result
+        fetch(std::string_view asset_code,
+              std::chrono::time_point<std::chrono::system_clock,
+                                      std::chrono::minutes>
+                  start_period,
+              std::chrono::time_point<std::chrono::system_clock,
+                                      std::chrono::minutes>
+                  end_period,
+              timeframe tf) override;
 
       private:
-        // check if from < to. If from > to swap the values
-        static void valid_dates(day_point &from, day_point &to);
-        static std::map<date::year_month_day, double>
-        generate_historical_data(day_point from, day_point to);
+        static std::map<std::chrono::time_point<std::chrono::system_clock,
+                                                std::chrono::minutes>,
+                        double>
+        generate_historical_data(
+            std::chrono::time_point<std::chrono::system_clock,
+                                    std::chrono::minutes>
+                start_period,
+            std::chrono::time_point<std::chrono::system_clock,
+                                    std::chrono::minutes>
+                end_period,
+            timeframe tf);
+        static std::chrono::minutes calculate_increment(timeframe tf);
     };
 }
 

--- a/source/portfolio/data_feed/mock_data_feed.h
+++ b/source/portfolio/data_feed/mock_data_feed.h
@@ -5,12 +5,15 @@
 #ifndef PORTFOLIO_MOCK_DATA_FEED_H
 #define PORTFOLIO_MOCK_DATA_FEED_H
 
+#include "date/date.h"
 #include <portfolio/data_feed/data_feed.h>
 
 namespace portfolio {
     class mock_data_feed : public data_feed {
     public:
-        data_feed_result fetch(std::string_view) override;
+      data_feed_result fetch(std::string_view) override;
+      data_feed_result fetch_from(std::string_view, date::year_month_day,
+                                  date::year_month_day) override;
     };
 }
 

--- a/tests/unit_tests/ut_data_feed.cpp
+++ b/tests/unit_tests/ut_data_feed.cpp
@@ -5,7 +5,16 @@
 
 TEST_CASE("Data Feed") {
     using namespace portfolio;
+    using namespace date::literals;
     mock_data_feed m;
     data_feed_result r = m.fetch("PETR3");
+    data_feed_result r2 =
+        m.fetch_from("PETR4", 2019_y / 01 / 01, 2019_y / 01 / 10);
     REQUIRE(r.current_price() != 0.0);
+    REQUIRE(r2.price_from_date(2018_y / 12 / 31) ==
+            r2.price_from_date(2019_y / 01 / 01));
+    REQUIRE(r2.price_from_date(2019_y / 01 / 01) != 0.0);
+    REQUIRE(r2.price_from_date(2020_y / 01 / 01) != 0.0);
+    REQUIRE(r2.price_from_date(2020_y / 01 / 01) ==
+            r2.price_from_date(2019_y / 12 / 31));
 }

--- a/tests/unit_tests/ut_data_feed.cpp
+++ b/tests/unit_tests/ut_data_feed.cpp
@@ -22,5 +22,5 @@ TEST_CASE("Data Feed") {
 
     // If request the price of a weekend day returns the price of Friday.
     REQUIRE(r.price(2019_y / 01 / 05) == r.price(2019_y / 01 / 04));
-    REQUIRE(r.price(2020_y / 01 / 04) == r.price(2020_y / 01 / 06));
+    REQUIRE(r.price(2019_y / 01 / 06) == r.price(2019_y / 01 / 04));
 }

--- a/tests/unit_tests/ut_data_feed.cpp
+++ b/tests/unit_tests/ut_data_feed.cpp
@@ -8,26 +8,19 @@ TEST_CASE("Data Feed") {
     using namespace date::literals;
     mock_data_feed m;
     // data_feed_result r = m.fetch("PETR3");
-    data_feed_result r =
-        m.fetch_from("PETR4", 2019_y / 01 / 01, 2019_y / 12 / 31);
+    data_feed_result r = m.fetch("PETR4", 2019_y / 01 / 01, 2019_y / 12 / 31);
 
     // If request the price of a date before the oldest date returns the price
     // of the oldest period.
-    REQUIRE(r.price_from_date(2018_y / 12 / 31) ==
-            r.price_from_date(2019_y / 01 / 01));
-    REQUIRE(r.price_from_date(2018_y / 12 / 30) ==
-            r.price_from_date(2018_y / 12 / 29));
+    REQUIRE(r.price(2018_y / 12 / 31) == r.price(2019_y / 01 / 01));
+    REQUIRE(r.price(2018_y / 12 / 30) == r.price(2018_y / 12 / 29));
 
     // If request the price of a date after the newest date returns the price
     // of the newest period.
-    REQUIRE(r.price_from_date(2019_y / 12 / 31) ==
-            r.price_from_date(2020_y / 01 / 01));
-    REQUIRE(r.price_from_date(2020_y / 01 / 01) ==
-            r.price_from_date(2020_y / 01 / 02));
+    REQUIRE(r.price(2019_y / 12 / 31) == r.price(2020_y / 01 / 01));
+    REQUIRE(r.price(2020_y / 01 / 01) == r.price(2020_y / 01 / 02));
 
     // If request the price of a weekend day returns the price of Friday.
-    REQUIRE(r.price_from_date(2019_y / 01 / 04) ==
-            r.price_from_date(2019_y / 01 / 05));
-    REQUIRE(r.price_from_date(2020_y / 01 / 04) ==
-            r.price_from_date(2020_y / 01 / 06));
+    REQUIRE(r.price(2019_y / 01 / 05) == r.price(2019_y / 01 / 04));
+    REQUIRE(r.price(2020_y / 01 / 04) == r.price(2020_y / 01 / 06));
 }

--- a/tests/unit_tests/ut_data_feed.cpp
+++ b/tests/unit_tests/ut_data_feed.cpp
@@ -1,26 +1,159 @@
 #define CATCH_CONFIG_MAIN
 
 #include <catch2/catch.hpp>
+#include <chrono>
 #include <portfolio/data_feed/mock_data_feed.h>
 
 TEST_CASE("Data Feed") {
     using namespace portfolio;
     using namespace date::literals;
+    using namespace std::chrono_literals;
     mock_data_feed m;
-    // data_feed_result r = m.fetch("PETR3");
-    data_feed_result r = m.fetch("PETR4", 2019_y / 01 / 01, 2019_y / 12 / 31);
 
-    // If request the price of a date before the oldest date returns the price
-    // of the oldest period.
-    REQUIRE(r.price(2018_y / 12 / 31) == r.price(2019_y / 01 / 01));
-    REQUIRE(r.price(2018_y / 12 / 30) == r.price(2018_y / 12 / 29));
+    data_feed_result r_daily =
+        m.fetch("PETR4", date::sys_days{date::January / 1 / 2019} + 10h + 0min,
+                date::sys_days{date::December / 31 / 2019} + 18h + 0min,
+                timeframe::daily);
+    data_feed_result r_minutes15 =
+        m.fetch("PETR4", date::sys_days{date::January / 1 / 2019} + 10h + 0min,
+                date::sys_days{date::December / 31 / 2019} + 18h + 0min,
+                timeframe::minutes_15);
+    data_feed_result r_weekly =
+        m.fetch("PETR4", date::sys_days{date::January / 1 / 2019} + 10h + 0min,
+                date::sys_days{date::December / 31 / 2019} + 18h + 0min,
+                timeframe::weekly);
 
-    // If request the price of a date after the newest date returns the price
-    // of the newest period.
-    REQUIRE(r.price(2019_y / 12 / 31) == r.price(2020_y / 01 / 01));
-    REQUIRE(r.price(2020_y / 01 / 01) == r.price(2020_y / 01 / 02));
+    data_feed_result r_monthly =
+        m.fetch("PETR4", date::sys_days{date::January / 1 / 2019} + 10h + 0min,
+                date::sys_days{date::December / 31 / 2019} + 18h + 0min,
+                timeframe::monthly);
 
-    // If request the price of a weekend day returns the price of Friday.
-    REQUIRE(r.price(2019_y / 01 / 05) == r.price(2019_y / 01 / 04));
-    REQUIRE(r.price(2019_y / 01 / 06) == r.price(2019_y / 01 / 04));
+    data_feed_result r_hourly =
+        m.fetch("PETR4", date::sys_days{date::January / 1 / 2019} + 10h + 0min,
+                date::sys_days{date::December / 31 / 2019} + 18h + 0min,
+                timeframe::hourly);
+
+    // if request the price of inexistent data and time returns -1
+    REQUIRE(r_daily.price_from(date::sys_days{2019_y / 01 / 01} + 10h + 0min) !=
+            -1);
+    REQUIRE(r_daily.price_from(date::sys_days{2019_y / 01 / 01} + 10h +
+                               01min) == -1);
+    REQUIRE(r_daily.price_from(date::sys_days{2018_y / 12 / 31} + 10h + 0min) ==
+            -1);
+    REQUIRE(r_daily.price_from(date::sys_days{2020_y / 01 / 01} + 10h + 0min) ==
+            -1);
+    REQUIRE(r_minutes15.price_from(date::sys_days{2019_y / 01 / 01} + 10h +
+                                   0min) != -1);
+    REQUIRE(r_minutes15.price_from(date::sys_days{2019_y / 01 / 01} + 10h +
+                                   01min) == -1);
+    REQUIRE(r_minutes15.price_from(date::sys_days{2018_y / 12 / 31} + 10h +
+                                   0min) == -1);
+    REQUIRE(r_minutes15.price_from(date::sys_days{2020_y / 01 / 01} + 10h +
+                                   0min) == -1);
+    REQUIRE(r_weekly.price_from(date::sys_days{2019_y / 01 / 01} + 10h +
+                                0min) != -1);
+    REQUIRE(r_weekly.price_from(date::sys_days{2019_y / 01 / 01} + 10h +
+                                01min) == -1);
+    REQUIRE(r_weekly.price_from(date::sys_days{2018_y / 12 / 31} + 10h +
+                                0min) == -1);
+    REQUIRE(r_weekly.price_from(date::sys_days{2020_y / 01 / 01} + 10h +
+                                0min) == -1);
+    REQUIRE(r_monthly.price_from(date::sys_days{2019_y / 01 / 01} + 10h +
+                                 0min) != -1);
+    REQUIRE(r_monthly.price_from(date::sys_days{2019_y / 01 / 01} + 10h +
+                                 01min) == -1);
+    REQUIRE(r_monthly.price_from(date::sys_days{2018_y / 12 / 31} + 10h +
+                                 0min) == -1);
+    REQUIRE(r_monthly.price_from(date::sys_days{2020_y / 01 / 01} + 10h +
+                                 0min) == -1);
+    REQUIRE(r_hourly.price_from(date::sys_days{2019_y / 01 / 01} + 10h +
+                                0min) != -1);
+    REQUIRE(r_hourly.price_from(date::sys_days{2019_y / 01 / 01} + 10h +
+                                01min) == -1);
+    REQUIRE(r_hourly.price_from(date::sys_days{2018_y / 12 / 31} + 10h +
+                                0min) == -1);
+    REQUIRE(r_hourly.price_from(date::sys_days{2020_y / 01 / 01} + 10h +
+                                0min) == -1);
+
+    // If request the closest price of a date before the oldest date returns the
+    // price of the oldest period.
+    REQUIRE(r_daily.closest_price(date::sys_days{2018_y / 12 / 31} + 10h) ==
+            r_daily.closest_price(date::sys_days{2019_y / 01 / 01} + 10h));
+    REQUIRE(r_daily.closest_price(date::sys_days{2018_y / 12 / 30} + 10h) ==
+            r_daily.closest_price(date::sys_days{2018_y / 12 / 29} + 10h));
+    REQUIRE(r_minutes15.closest_price(date::sys_days{2019_y / 01 / 01} + 9h) ==
+            r_minutes15.closest_price(date::sys_days{2019_y / 01 / 01} + 10h));
+    REQUIRE(r_minutes15.closest_price(date::sys_days{2018_y / 12 / 30} + 10h) ==
+            r_minutes15.closest_price(date::sys_days{2018_y / 12 / 29} + 10h));
+    REQUIRE(r_weekly.closest_price(date::sys_days{2018_y / 12 / 31} + 10h) ==
+            r_weekly.closest_price(date::sys_days{2019_y / 01 / 01} + 10h));
+    REQUIRE(r_weekly.closest_price(date::sys_days{2018_y / 12 / 30} + 10h) ==
+            r_weekly.closest_price(date::sys_days{2018_y / 12 / 29} + 10h));
+    REQUIRE(r_monthly.closest_price(date::sys_days{2018_y / 12 / 31} + 10h) ==
+            r_monthly.closest_price(date::sys_days{2019_y / 01 / 01} + 10h));
+    REQUIRE(r_monthly.closest_price(date::sys_days{2018_y / 12 / 30} + 10h) ==
+            r_monthly.closest_price(date::sys_days{2018_y / 12 / 29} + 10h));
+    REQUIRE(r_hourly.closest_price(date::sys_days{2019_y / 01 / 01} + 9h) ==
+            r_hourly.closest_price(date::sys_days{2019_y / 01 / 01} + 10h));
+    REQUIRE(r_hourly.closest_price(date::sys_days{2018_y / 12 / 30} + 10h) ==
+            r_hourly.closest_price(date::sys_days{2018_y / 12 / 29} + 10h));
+
+    // If request the closest price of a date after the newest date returns the
+    // price of the newest period.
+    REQUIRE(r_daily.closest_price(date::sys_days{2019_y / 12 / 31} + 10h) ==
+            r_daily.closest_price(date::sys_days{2020_y / 01 / 01} + 10h));
+    REQUIRE(r_daily.closest_price(date::sys_days{2020_y / 01 / 01} + 10h) ==
+            r_daily.closest_price(date::sys_days{2020_y / 01 / 02} + 10h));
+    REQUIRE(r_minutes15.closest_price(date::sys_days{2019_y / 12 / 31} + 18h) ==
+            r_minutes15.closest_price(date::sys_days{2020_y / 01 / 01} + 10h));
+    REQUIRE(r_minutes15.closest_price(date::sys_days{2020_y / 01 / 01} + 10h) ==
+            r_minutes15.closest_price(date::sys_days{2020_y / 01 / 02} + 10h));
+    REQUIRE(r_weekly.closest_price(date::sys_days{2019_y / 12 / 31} + 10h) ==
+            r_weekly.closest_price(date::sys_days{2020_y / 01 / 01} + 10h));
+    REQUIRE(r_weekly.closest_price(date::sys_days{2020_y / 01 / 01} + 10h) ==
+            r_weekly.closest_price(date::sys_days{2020_y / 01 / 02} + 10h));
+    REQUIRE(r_monthly.closest_price(date::sys_days{2019_y / 12 / 31} + 10h) ==
+            r_monthly.closest_price(date::sys_days{2020_y / 01 / 01} + 10h));
+    REQUIRE(r_monthly.closest_price(date::sys_days{2020_y / 01 / 01} + 10h) ==
+            r_monthly.closest_price(date::sys_days{2020_y / 01 / 02} + 10h));
+    REQUIRE(r_hourly.closest_price(date::sys_days{2019_y / 12 / 31} + 18h) ==
+            r_hourly.closest_price(date::sys_days{2020_y / 01 / 01} + 10h));
+    REQUIRE(r_hourly.closest_price(date::sys_days{2020_y / 01 / 01} + 10h) ==
+            r_hourly.closest_price(date::sys_days{2020_y / 01 / 02} + 10h));
+
+    // If request the closest price of a weekend day returns the price of
+    // Friday.
+    REQUIRE(r_daily.closest_price(date::sys_days{2019_y / 01 / 05} + 10h) ==
+            r_daily.closest_price(date::sys_days{2019_y / 01 / 04} + 10h));
+    REQUIRE(r_daily.closest_price(date::sys_days{2019_y / 01 / 06} + 10h) ==
+            r_daily.closest_price(date::sys_days{2019_y / 01 / 04} + 10h));
+    REQUIRE(r_minutes15.closest_price(date::sys_days{2019_y / 01 / 05} + 10h) ==
+            r_minutes15.closest_price(date::sys_days{2019_y / 01 / 04} + 18h));
+    REQUIRE(r_minutes15.closest_price(date::sys_days{2019_y / 01 / 06} + 10h) ==
+            r_minutes15.closest_price(date::sys_days{2019_y / 01 / 04} + 18h));
+    REQUIRE(r_weekly.closest_price(date::sys_days{2019_y / 01 / 05} + 10h) ==
+            r_weekly.closest_price(date::sys_days{2019_y / 01 / 04} + 10h));
+    REQUIRE(r_weekly.closest_price(date::sys_days{2019_y / 01 / 06} + 10h) ==
+            r_weekly.closest_price(date::sys_days{2019_y / 01 / 04} + 10h));
+    REQUIRE(r_monthly.closest_price(date::sys_days{2019_y / 01 / 05} + 10h) ==
+            r_monthly.closest_price(date::sys_days{2019_y / 01 / 04} + 10h));
+    REQUIRE(r_monthly.closest_price(date::sys_days{2019_y / 01 / 06} + 10h) ==
+            r_monthly.closest_price(date::sys_days{2019_y / 01 / 04} + 10h));
+    REQUIRE(r_hourly.closest_price(date::sys_days{2019_y / 01 / 05} + 10h) ==
+            r_hourly.closest_price(date::sys_days{2019_y / 01 / 04} + 18h));
+    REQUIRE(r_hourly.closest_price(date::sys_days{2019_y / 01 / 06} + 10h) ==
+            r_hourly.closest_price(date::sys_days{2019_y / 01 / 04} + 18h));
+
+    // if requesting the most recent price returns the most recent price in
+    // historical
+    REQUIRE(r_daily.lastest_price() ==
+            r_daily.price_from(date::sys_days{2019_y / 12 / 31} + 10h));
+    REQUIRE(r_minutes15.lastest_price() ==
+            r_minutes15.price_from(date::sys_days{2019_y / 12 / 31} + 18h));
+    REQUIRE(r_weekly.lastest_price() ==
+            r_weekly.price_from(date::sys_days{2019_y / 12 / 31} + 10h));
+    REQUIRE(r_monthly.lastest_price() ==
+            r_monthly.price_from(date::sys_days{2019_y / 11 / 07} + 10h));
+    REQUIRE(r_hourly.lastest_price() ==
+            r_hourly.price_from(date::sys_days{2019_y / 12 / 31} + 18h));
 }

--- a/tests/unit_tests/ut_data_feed.cpp
+++ b/tests/unit_tests/ut_data_feed.cpp
@@ -7,14 +7,27 @@ TEST_CASE("Data Feed") {
     using namespace portfolio;
     using namespace date::literals;
     mock_data_feed m;
-    data_feed_result r = m.fetch("PETR3");
-    data_feed_result r2 =
-        m.fetch_from("PETR4", 2019_y / 01 / 01, 2019_y / 01 / 10);
-    REQUIRE(r.current_price() != 0.0);
-    REQUIRE(r2.price_from_date(2018_y / 12 / 31) ==
-            r2.price_from_date(2019_y / 01 / 01));
-    REQUIRE(r2.price_from_date(2019_y / 01 / 01) != 0.0);
-    REQUIRE(r2.price_from_date(2020_y / 01 / 01) != 0.0);
-    REQUIRE(r2.price_from_date(2020_y / 01 / 01) ==
-            r2.price_from_date(2019_y / 12 / 31));
+    // data_feed_result r = m.fetch("PETR3");
+    data_feed_result r =
+        m.fetch_from("PETR4", 2019_y / 01 / 01, 2019_y / 12 / 31);
+
+    // If request the price of a date before the oldest date returns the price
+    // of the oldest period.
+    REQUIRE(r.price_from_date(2018_y / 12 / 31) ==
+            r.price_from_date(2019_y / 01 / 01));
+    REQUIRE(r.price_from_date(2018_y / 12 / 30) ==
+            r.price_from_date(2018_y / 12 / 29));
+
+    // If request the price of a date after the newest date returns the price
+    // of the newest period.
+    REQUIRE(r.price_from_date(2019_y / 12 / 31) ==
+            r.price_from_date(2020_y / 01 / 01));
+    REQUIRE(r.price_from_date(2020_y / 01 / 01) ==
+            r.price_from_date(2020_y / 01 / 02));
+
+    // If request the price of a weekend day returns the price of Friday.
+    REQUIRE(r.price_from_date(2019_y / 01 / 04) ==
+            r.price_from_date(2019_y / 01 / 05));
+    REQUIRE(r.price_from_date(2020_y / 01 / 04) ==
+            r.price_from_date(2020_y / 01 / 06));
 }


### PR DESCRIPTION
Change the structure of historical from year_month_day to time_point to make the code more generic. Create in data_feed_result the distinction between the return of the price of an exact time_point and an approximate time_point. Include the enum timeframe in data_feed.